### PR TITLE
Close menu on clicking outside menu

### DIFF
--- a/js/jPushMenu.js
+++ b/js/jPushMenu.js
@@ -63,10 +63,13 @@
 
         // Close menu on clicking outside menu
         if (o.closeOnClickOutside) {
-             $(document).click(function() {
-                jPushMenu.close(o);
-             });
-         }
+            $(document).on('click', function() {
+                jPushMenu.close(o);       
+            });
+            $(".cbp-spmenu").on('click', function(e) {
+                e.stopPropagation();
+            });
+        }
 
         // Close menu on clicking menu link
         if (o.closeOnClickLink) {


### PR DESCRIPTION
Added e.stopPropagation() for .cbp-spmenu class. It's possible clicking inside menu without close them. Standard <a> tags working differently and menu disappear when you press them.
