### PR TITLE
Fix bug when closeOnClickLink is false

### DIFF
--- a/js/jPushMenu.js
+++ b/js/jPushMenu.js
@@ -63,8 +63,10 @@
 
         // Close menu on clicking outside menu
         if (o.closeOnClickOutside) {
-             $(document).click(function() {
-                jPushMenu.close(o);
+             $(document).click(function(e) {
+                if (!$(e.target).closest('.cbp-spmenu').length && $('.cbp-spmenu').is('.' + o.menuOpenClass)) {
+                    jPushMenu.close(o);
+                }
              });
          }
 


### PR DESCRIPTION
Setting the "closeOnClickLink" option to "false" when initializing
jPushMenu has no effect. This is caused by $(document).click() on line
66 in file jPushMenu.js, which doesn't check if the event target is a
child of the menu or not
